### PR TITLE
Fix - edge case false positive.

### DIFF
--- a/HMACAuthentication.WebApi/Filters/HMACAuthenticationAttribute.cs
+++ b/HMACAuthentication.WebApi/Filters/HMACAuthenticationAttribute.cs
@@ -19,7 +19,7 @@ namespace HMACAuthentication.WebApi.Filters
     public class HMACAuthenticationAttribute : Attribute, IAuthenticationFilter
     {
         private static Dictionary<string, string> allowedApps = new Dictionary<string, string>();
-        private readonly UInt64 requestMaxAgeInSeconds = 300;  //5 mins
+        private readonly long requestMaxAgeInSeconds = 300;  //5 mins
         private readonly string authenticationScheme = "amx";
 
         public HMACAuthenticationAttribute()
@@ -152,7 +152,7 @@ namespace HMACAuthentication.WebApi.Filters
             var serverTotalSeconds = Convert.ToUInt64(currentTs.TotalSeconds);
             var requestTotalSeconds = Convert.ToUInt64(requestTimeStamp);
 
-            if ((serverTotalSeconds - requestTotalSeconds) > requestMaxAgeInSeconds)
+            if (Math.Abs((Int64)(serverTotalSeconds - requestTotalSeconds)) > requestMaxAgeInSeconds)
             {
                 return true;
             }


### PR DESCRIPTION
When the WebApi server's clock is slower than the client's clock, (serverTotalSeconds - requestTotalSeconds) will result in a negative number.  Because of UInt this becomes an extremely large number, causing false positive for replay attack.  While its a legitimate request with clocks being off by few seconds.
Casting (serverTotalSeconds - requestTotalSeconds) to a long(or Int64) returns a small negative number.
But using Math.Abs will cover the case where the clocks are significantly off (more than 300 secs in this case).